### PR TITLE
IN-250: ensure build jobs don't pip/apt-get install

### DIFF
--- a/build/openstack_horizon_bsn.build
+++ b/build/openstack_horizon_bsn.build
@@ -1,0 +1,18 @@
+git clean -fxd
+GIT_REPO=`pwd`
+
+# get gpg creds in place
+GNUPG_DIR=$(mktemp -d)
+tar -zxvf $GNUPG_TAR -C $GNUPG_DIR
+
+DOCKER_IMAGE=$DOCKER_REGISTRY'/bosi-builder:latest'
+
+echo "Tagging and uploading to PYPI"
+docker pull $DOCKER_IMAGE
+docker run -e GIT_BRANCH=$GIT_BRANCH -v $GIT_REPO:/horizon-bsn -v $PYPIRC_FILE:/root/.pypirc -v $GNUPG_DIR/.gnupg:/root/.gnupg $DOCKER_IMAGE /horizon-bsn/build/upload_to_pypi.sh
+
+# remove pypi and gpg creds
+sudo rm -rf $GNUPG_DIR
+
+echo "Building RPM packages"
+./build/build-rhel-packages.sh

--- a/build/openstack_horizon_bsn_pull_req.build
+++ b/build/openstack_horizon_bsn_pull_req.build
@@ -1,0 +1,1 @@
+./build/precheckin.sh

--- a/build/precheckin.sh
+++ b/build/precheckin.sh
@@ -2,7 +2,6 @@
 pwd
 echo 'git commit is' ${GIT_COMMIT}
 git clean -fxd
-sudo pip install --upgrade 'tox==2.3.1'
 tox -e pep8
 setup_cfg_modified=`git log -m -1 --name-only --pretty="format:" | grep setup.cfg | wc -l`
 if [ ${setup_cfg_modified} -ne 1 ];

--- a/build/upload_to_pypi.sh
+++ b/build/upload_to_pypi.sh
@@ -1,11 +1,16 @@
 #!/bin/bash -eux
-# install twine, to be added to infra puppet script
-sudo -H pip install twine
-CURR_VERSION=$(awk '/^version/{print $3}' setup.cfg)
 
-# get pypi and gpg creds in place
-mv $PYPIRC_FILE ~/.pypirc
-tar -zxvf $GNUPG_TAR -C ~/
+# RPM runs as root and doesn't like source files owned by a random UID
+OUTER_UID=$(stat -c '%u' /horizon-bsn)
+OUTER_GID=$(stat -c '%g' /horizon-bsn)
+trap "chown -R $OUTER_UID:$OUTER_GID /horizon-bsn" EXIT
+chown -R root:root /horizon-bsn
+
+cd /horizon-bsn
+git config --global user.name "Big Switch Networks"
+git config --global user.email "support@bigswitch.com"
+
+CURR_VERSION=$(awk '/^version/{print $3}' setup.cfg)
 
 echo 'CURR_VERSION=' $CURR_VERSION
 git tag -f -s $CURR_VERSION -m $CURR_VERSION -u "Big Switch Networks"
@@ -16,7 +21,7 @@ python setup.py sdist
 twine upload dist/* -r pypi -s -i "Big Switch Networks" || true
 # delay of 5 seconds
 sleep 5
-sudo -H pip install --no-cache-dir --upgrade horizon-bsn==$CURR_VERSION
+sudo -H pip install --upgrade horizon-bsn==$CURR_VERSION
 if [ "$?" -eq "0" ]
 then
   echo "PYPI upload successful."
@@ -26,6 +31,5 @@ fi
 # remove the package
 sudo -H pip uninstall -y horizon-bsn
 
-# remove pypi and gpg creds
-rm ~/.pypirc
-rm -rf ~/.gnupg
+# revert the permissions
+chown -R $OUTER_UID:$OUTER_GID /horizon-bsn

--- a/rhel/python-horizon-bsn.spec
+++ b/rhel/python-horizon-bsn.spec
@@ -5,7 +5,7 @@
 %global lib_dir %{buildroot}%{python2_sitelib}/%{pypi_name}/plugins/bigswitch
 
 Name:           python-%{rpm_name}
-Version:        0.0.29
+Version:        0.0.30
 Release:        1%{?dist}
 Summary:        Big Switch Networks horizon plugin for OpenStack
 License:        ASL 2.0
@@ -72,6 +72,8 @@ done
 %postun
 
 %changelog
+* Mon Aug 28 2017 Aditya Vaja <wolverine.av@gmail.com> - 0.0.30
+- build changes
 * Tue Jun 13 2017 Aditya Vaja <wolverine.av@gmail.com> - 0.0.29
 - OSP-36: missed a replacement for quicktest tenant get
 * Mon Jun 05 2017 Aditya Vaja <wolverine.av@gmail.com> - 0.0.28

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = horizon-bsn
-version = 0.0.29
+version = 0.0.30
 summary = Big Switch Networks Extension for the Openstack Dashboard (Horizon).
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: @sarath-kumar 

- moving the build and upload to pypi inside container
- all the openstack_*.build files are what the content of the shell script should be for jenkins jobs
- this is to keep easier track of build changes over time