### PR TITLE
BCF-9905: fix superclass deprecations causing error during horizon startup

### DIFF
--- a/horizon_bsn/content/connections/network_template/tables.py
+++ b/horizon_bsn/content/connections/network_template/tables.py
@@ -15,6 +15,7 @@ from django.http import Http404
 from django.utils.safestring import mark_safe
 from django.utils.translation import pgettext_lazy
 from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ungettext_lazy
 from horizon import messages
 from horizon import tables
 from horizon_bsn.api import neutron
@@ -235,6 +236,22 @@ class DeleteTemplateAction(tables.DeleteAction):
             messages.error(
                 request, _("Unable to delete template. Template may "
                            "be in use by a tenant."))
+
+    @staticmethod
+    def action_present(count):
+        return ungettext_lazy(
+            u"Delete Network Template",
+            u"Delete Network Templates",
+            count
+        )
+
+    @staticmethod
+    def action_past(count):
+        return ungettext_lazy(
+            u"Deleted Network Template",
+            u"Deleted Network Templates",
+            count
+        )
 
 
 class CreateTemplateAction(tables.LinkAction):

--- a/horizon_bsn/content/connections/reachability_tests/tables.py
+++ b/horizon_bsn/content/connections/reachability_tests/tables.py
@@ -17,6 +17,7 @@ from horizon.utils import filters
 
 from django.template.defaultfilters import title
 from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ungettext_lazy
 from horizon_bsn.api import neutron
 
 
@@ -30,6 +31,22 @@ class DeleteReachabilityTests(tables.DeleteAction):
         except Exception:
             exceptions.handle(request,
                               _("Failed to update reachability test"))
+
+    @staticmethod
+    def action_present(count):
+        return ungettext_lazy(
+            u"Delete Reachability Test",
+            u"Delete Reachability Tests",
+            count
+        )
+
+    @staticmethod
+    def action_past(count):
+        return ungettext_lazy(
+            u"Deleted Reachability Test",
+            u"Deleted Reachability Tests",
+            count
+        )
 
 
 class CreateReachabilityTest(tables.LinkAction):
@@ -57,13 +74,27 @@ class ReachabilityTestFilterAction(tables.FilterAction):
 
 class RunTest(tables.BatchAction):
     name = "run"
-    action_present = _("Run")
-    action_past = _("Running")
     data_type_singular = _("Test")
     classes = ("btn-edit", )
 
     def action(self, request, id):
         neutron.reachabilitytest_update(request, id, **{'run_test': True})
+
+    @staticmethod
+    def action_present(count):
+        return ungettext_lazy(
+            u"Run Reachability Test",
+            u"Run Reachability Tests",
+            count
+        )
+
+    @staticmethod
+    def action_past(count):
+        return ungettext_lazy(
+            u"Running Reachability Test",
+            u"Running Reachability Tests",
+            count
+        )
 
 
 class UpdateTest(tables.LinkAction):

--- a/rhel/python-horizon-bsn.spec
+++ b/rhel/python-horizon-bsn.spec
@@ -5,7 +5,7 @@
 %global lib_dir %{buildroot}%{python2_sitelib}/%{pypi_name}/plugins/bigswitch
 
 Name:           python-%{rpm_name}
-Version:        0.0.32
+Version:        0.0.33
 Release:        1%{?dist}
 Summary:        Big Switch Networks horizon plugin for OpenStack
 License:        ASL 2.0
@@ -72,6 +72,8 @@ done
 %postun
 
 %changelog
+* Thu Feb 08 2017 Aditya Vaja <wolverine.av@gmail.com> - 0.0.33
+- BCF-9905: fix superclass deprecations causing error during horizon startup
 * Tue Oct 24 2017 Aditya Vaja <wolverine.av@gmail.com> - 0.0.32
 - OSP-17: move policies from router to tenant + L4 ACL
 * Fri Oct 20 2017 Aditya Vaja <wolverine.av@gmail.com> - 0.0.31

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = horizon-bsn
-version = 0.0.32
+version = 0.0.33
 summary = Big Switch Networks Extension for the Openstack Dashboard (Horizon).
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: trivial
CC: @sarath-kumar 

 - this would be backported to stable/pike