### PR TITLE
EXT-80: customize horizon container for bsn plugin enablement

### DIFF
--- a/build/build-rhel-packages.sh
+++ b/build/build-rhel-packages.sh
@@ -21,6 +21,7 @@ rm -rf "$OUTDIR" && mkdir -p "$OUTDIR"
 mv $BUILDDIR/SRPMS/*.rpm "$OUTDIR"
 mv $BUILDDIR/RPMS/noarch/*.rpm "$OUTDIR"
 cp dist/*.tar.gz "$OUTDIR"
+cp rhel/horizon_container_workaround.sh "$OUTDIR"
 git log > "$OUTDIR/gitlog.txt"
 touch "$OUTDIR/build-$CURR_VERSION"
 ln -snf $(basename $OUTDIR) $OUTDIR/../latest

--- a/rhel/horizon_container_workaround.sh
+++ b/rhel/horizon_container_workaround.sh
@@ -1,8 +1,9 @@
 #!/bin/bash -eux
 
 CONTAINER_BUILD_DIR='openstack_horizon_bigswitch'
+BSN_HORIZON_TAG='12.0.1'
 
-# recreate worksapace for container build
+# recreate workspace for container build
 rm -rf ${CONTAINER_BUILD_DIR}
 mkdir -p ${CONTAINER_BUILD_DIR}
 
@@ -37,9 +38,9 @@ RUN cp /usr/lib/python2.7/site-packages/horizon_bsn/enabled/* /usr/lib/python2.7
 # USER horizon
 EOF
 
-sudo docker build ./ -t latest_bsn_tag
-IMAGE_ID=`sudo docker images -q latest_bsn_tag`
+sudo docker build ./ -t ${BSN_HORIZON_TAG}
+IMAGE_ID=`sudo docker images -q ${BSN_HORIZON_TAG}`
 
 # tag latest build image and push to local registry
-sudo docker tag ${IMAGE_ID} ${LOCAL_REGISTRY_ADDRESS}/openstack-horizon-bigswitch:latest_bsn_tag
-sudo docker push ${LOCAL_REGISTRY_ADDRESS}/openstack-horizon-bigswitch:latest_bsn_tag
+sudo docker tag ${IMAGE_ID} ${LOCAL_REGISTRY_ADDRESS}/openstack-horizon-bigswitch:${BSN_HORIZON_TAG}
+sudo docker push ${LOCAL_REGISTRY_ADDRESS}/openstack-horizon-bigswitch:${BSN_HORIZON_TAG}

--- a/rhel/horizon_container_workaround.sh
+++ b/rhel/horizon_container_workaround.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -eux
+
+CONTAINER_BUILD_DIR='openstack_horizon_bigswitch'
+
+# recreate worksapace for container build
+rm -rf ${CONTAINER_BUILD_DIR}
+mkdir -p ${CONTAINER_BUILD_DIR}
+
+# copy required packages to build dir
+cp python-horizon-bsn-*.rpm ${CONTAINER_BUILD_DIR}/
+curl -O "http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/p/python-lockfile-0.9.1-4.el7.noarch.rpm"
+cp python-lockfile*.rpm ${CONTAINER_BUILD_DIR}/
+
+# container tag_id used to deploy overcloud
+UPSTREAM_TAG=`sudo openstack overcloud container image tag discover \
+--image registry.access.redhat.com/rhosp12/openstack-base:latest \
+--tag-from-label version-release`
+
+# local registry address to push image
+LOCAL_REGISTRY_ADDRESS=`docker images | grep -v redhat.com | grep -o '^.*rhosp12' | sort -u`
+
+cd ${CONTAINER_BUILD_DIR}
+
+cat > Dockerfile <<EOF
+FROM ${LOCAL_REGISTRY_ADDRESS}/openstack-horizon:${UPSTREAM_TAG}
+MAINTAINER Big Switch Networks Inc.
+LABEL name="rhosp12/openstack-horizon-bigswitch" vendor="Big Switch Networks Inc" version="11.0" release="1"
+
+# switch to root and install a custom RPM, etc.
+USER root
+COPY python-horizon-bsn*.rpm /tmp/
+COPY python-lockfile*.rpm /tmp/
+RUN rpm -ivh /tmp/*.rpm
+RUN cp /usr/lib/python2.7/site-packages/horizon_bsn/enabled/* /usr/lib/python2.7/site-packages/openstack_dashboard/local/enabled/
+# switch the container back to the default user (NOT)
+# doing this has permission denied error during startup. skip it.
+# USER horizon
+EOF
+
+sudo docker build ./ -t latest_bsn_tag
+IMAGE_ID=`sudo docker images -q latest_bsn_tag`
+
+# tag latest build image and push to local registry
+sudo docker tag ${IMAGE_ID} ${LOCAL_REGISTRY_ADDRESS}/openstack-horizon-bigswitch:latest_bsn_tag
+sudo docker push ${LOCAL_REGISTRY_ADDRESS}/openstack-horizon-bigswitch:latest_bsn_tag


### PR DESCRIPTION
Reviewer: @sarath-kumar 

 - additional step in RHOSP 12 deployment would be to execute the
   newly added script `horizon_container_workaround.sh`
 - this would customize the upstream horizon container to include
   BSN plugin and its `enable` files
 - previously required manual step to copy the `enable` files would 
   not be required

corresponding cherry-pick https://github.com/bigswitch/horizon-bsn/pull/109