### PR TITLE
update build scripts to use py3 container for running precheckin tox tests

### DIFF
--- a/build/openstack_horizon_bsn_pull_req.build
+++ b/build/openstack_horizon_bsn_pull_req.build
@@ -1,1 +1,11 @@
-./build/precheckin.sh
+git clean -fxd
+GIT_REPO=`pwd`
+
+DOCKER_IMAGE=$DOCKER_REGISTRY'/bosi-builder-py3:latest'
+docker pull $DOCKER_IMAGE
+
+docker run \
+    -e GIT_COMMIT=$GIT_COMMIT \
+    -v $GIT_REPO:/horizon-bsn \
+    $DOCKER_IMAGE \
+    /horizon-bsn/build/precheckin.sh

--- a/build/precheckin.sh
+++ b/build/precheckin.sh
@@ -1,8 +1,13 @@
 #!/bin/bash -eux
+
+# switch to git repo directory inside container
+cd /horizon-bsn
+
 pwd
 echo 'git commit is' ${GIT_COMMIT}
-git clean -fxd
+
 tox -e pep8
+
 setup_cfg_modified=`git log -m -1 --name-only --pretty="format:" | grep setup.cfg | wc -l`
 if [ ${setup_cfg_modified} -lt 1 ];
   then echo "Update setup.cfg with new version number. Build FAILED";
@@ -11,7 +16,7 @@ else
   echo "setup.cfg updated"; fi
 # check the new_version > old_version
 echo 'checking if version bump is correct'
-git log -m -1 ${GIT_COMMIT} --pretty="format:" -p setup.cfg | grep version | python build/is_version_bumped.py
+git log -m -1 ${GIT_COMMIT} --pretty="format:" -p setup.cfg | grep version | python3 build/is_version_bumped.py
 
 CURR_VERSION=$(awk '/^version/{print $3}' setup.cfg)
 SPEC_VERSION=$(awk '/^Version/{print $2}' rhel/python-horizon-bsn.spec)

--- a/rhel/python-horizon-bsn.spec
+++ b/rhel/python-horizon-bsn.spec
@@ -5,7 +5,7 @@
 %global lib_dir %{buildroot}%{python2_sitelib}/%{pypi_name}/plugins/bigswitch
 
 Name:           python-%{rpm_name}
-Version:        0.0.39
+Version:        0.0.40
 Release:        1%{?dist}
 Summary:        Big Switch Networks horizon plugin for OpenStack
 License:        ASL 2.0
@@ -72,11 +72,12 @@ done
 %postun
 
 %changelog
+* Thu Nov 29 2018 Aditya Vaja <wolverine.av@gmail.com> - 0.0.40
+- update build scripts to use py3 container for running precheckin tox tests
 * Wed Nov 20 2018 Weifan Fu <weifan.fu@bigswitch.com> - 0.0.39
 - OSP-251: transition to python3
 * Thu Nov 15 2018 Aditya Vaja <wolverine.av@gmail.com> - 0.0.38
 - OSP-191: display a nice to read error when neutron is not configured properly
->>>>>>> 1729dbee019bb42ceb27a446177d64b51c4309dc
 * Wed Oct 31 2018 Aditya Vaja <wolverine.av@gmail.com> - 0.0.37
 - OSP-220 OSP-221: update horizon for newer Django
 * Wed Sep 19 2018 Aditya Vaja <wolverine.av@gmail.com> - 0.0.36

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = horizon-bsn
-version = 0.0.39
+version = 0.0.40
 summary = Big Switch Networks Extension for the Openstack Dashboard (Horizon).
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: @sarath-kumar @WeifanFu-bsn 

 - same as the change for `python-bsn-neutronclient` yesterday