### PR TITLE
use sudo when doing a git clean

### DIFF
--- a/build/openstack_horizon_bsn.build
+++ b/build/openstack_horizon_bsn.build
@@ -1,4 +1,4 @@
-git clean -fxd
+sudo git clean -fxd
 GIT_REPO=`pwd`
 
 # get gpg creds in place

--- a/build/openstack_horizon_bsn_pull_req.build
+++ b/build/openstack_horizon_bsn_pull_req.build
@@ -1,4 +1,4 @@
-git clean -fxd
+sudo git clean -fxd
 GIT_REPO=`pwd`
 
 DOCKER_IMAGE=$DOCKER_REGISTRY'/bosi-builder-py3:latest'


### PR DESCRIPTION
 - because container creates .tox directory as root user, outside
   the container, cleaning requires sudo